### PR TITLE
Fix * permission remaining on player indefinitely

### DIFF
--- a/src/org/zonedabone/commandsigns/handler/CommandHandler.java
+++ b/src/org/zonedabone/commandsigns/handler/CommandHandler.java
@@ -5,6 +5,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.plugin.PluginManager;
 import org.zonedabone.commandsigns.CommandSigns;
 import org.zonedabone.commandsigns.SignExecutor;


### PR DESCRIPTION
By using a PermissionAttachment instead of the Vault Permissions object.

I am aware that you are building a replacement plugin, but I believe this is worth applying as a hotfix.
