### PR TITLE
Fixed the issue where "restriction.cooldown" would not be used

### DIFF
--- a/src/org/zonedabone/commandsigns/handler/CooldownHandler.java
+++ b/src/org/zonedabone/commandsigns/handler/CooldownHandler.java
@@ -47,7 +47,7 @@ public class CooldownHandler extends Handler {
 							plugin.messenger
 									.sendMessage(
 											e.getPlayer(),
-											"restriction.inverse_cooldown",
+											"restriction.cooldown",
 											new String[] { "COOLDOWN" },
 											new String[] { ""
 													+ Math.round((amount


### PR DESCRIPTION
I made this change for our Minecraft server.

I was reading the code and that's how I noticed this little, and insignificant bug, but I figured I'd fix it anyway.

So here's the fix :)
